### PR TITLE
Deal with string payloads and add to session as seperate message

### DIFF
--- a/src/ServerTypes.ts
+++ b/src/ServerTypes.ts
@@ -1,9 +1,12 @@
 export namespace ServerTypes {
     export type Msg = ClientConnectMsg | CreateSessionMsg | UpdateClientMsg | AddClientToSessionMsg | ClientJoinedSessionMsg | ClientLeftSessionMsg | BroadcastToSessionMsg | BroadcastFromSessionMsg | ErrorMsg | InfoMsg
 
+    export type Time = string; // Go times are serialised to strings
+
     export interface Client {
         id: string;
         name: string;
+        lastJoinTime: Time;
     }
     export interface Session {
         id: string;
@@ -16,7 +19,6 @@ export namespace ServerTypes {
     }
     export interface CreateSessionMsg {
         type: "CreateSession";
-        addClientId: string;
     }
     export interface UpdateClientMsg {
         type: "UpdateClient";
@@ -32,24 +34,24 @@ export namespace ServerTypes {
         clientId: string;
         sessionId: string;
         sessionOwnerId: string;
-        clientMap: { [key: string]: Client };
+        clientMap: {[key: string]: Client};
     }
     export interface ClientLeftSessionMsg {
         type: "ClientLeftSession";
         clientId: string;
         sessionId: string;
         sessionOwnerId: string;
-        clientMap: { [key: string]: Client };
+        clientMap: {[key: string]: Client};
     }
     export interface BroadcastToSessionMsg {
         type: "BroadcastToSession";
-        payload: any;
+        payload: string;
     }
     export interface BroadcastFromSessionMsg {
         type: "BroadcastFromSession";
         fromSessionOwner: boolean;
         senderId: string;
-        payload: any;
+        payload: string;
     }
     export interface ErrorMsg {
         type: "Error";

--- a/src/feature/session/SessionMessage.ts
+++ b/src/feature/session/SessionMessage.ts
@@ -16,7 +16,8 @@ export interface OpenWebsiteSessionMessage extends SessionMessage {
 }
 
 export function mapSessionMsg(serverMsg: ServerTypes.BroadcastFromSessionMsg): SessionMessage {
-    let sessionMsgType = serverMsg.payload["type"] as SessionMessageType | undefined;
+    const payload = JSON.parse(serverMsg.payload);
+    let sessionMsgType = payload["type"] as SessionMessageType | undefined;
     if (sessionMessageTypes.indexOf(sessionMsgType as SessionMessageType) < 0) {
         sessionMsgType = undefined;
     }
@@ -24,7 +25,7 @@ export function mapSessionMsg(serverMsg: ServerTypes.BroadcastFromSessionMsg): S
         uuid: ("" + Math.random() + "-" + Math.random()).replace(".", "0"),
         type: sessionMsgType,
         senderId: serverMsg.senderId,
-        senderName: serverMsg.payload["senderName"] ?? "",
-        text: serverMsg.payload["text"] ?? ""
+        senderName: payload["senderName"] ?? "",
+        text: payload["text"] ?? ""
     };
 }


### PR DESCRIPTION
To keep server simpler and easier to test use string payloads on session broadcast messages and add client to session after creation as a separate message (not within the create session message).